### PR TITLE
eip-4844 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ like you would with [geth's abigen](https://geth.ethereum.org/docs/tools/abigen)
 Just use Composer. Install the beta version for now.
 
 ```shell
-composer require m8b/ether-binder:v0.1.9-beta
+composer require m8b/ether-binder:v0.2.0-rc
 ```
 
 ## 📖 Documentation

--- a/src/Common/Block.php
+++ b/src/Common/Block.php
@@ -31,6 +31,7 @@ class Block
 	public Hash $transactionsRoot;
 	public Hash $stateRoot;
 	public Hash $receiptsRoot;
+	public ?Hash $parentBeaconBlockRoot;
 	public Address $miner;
 	public OOGmp $difficulty;
 	public OOGmp $totalDifficulty;
@@ -39,6 +40,8 @@ class Block
 	public ?OOGMP $baseFeePerGas;
 	public int $gasLimit;
 	public int $gasUsed;
+	public ?int $blobGasUsed;
+	public ?int $excessBlobGas;
 	public int $timestamp;
 	/** @var Transaction[]|Hash[] */
 	public array $transactions;
@@ -46,6 +49,7 @@ class Block
 	public array $uncles;
 	/** @var ValidatorWithdrawal[] */
 	public array $validatorWithdrawals;
+	public ?Hash $validatorWithdrawalsRoot;
 
 	/**
 	 * Constructs a Block object from an array received through RPC.
@@ -61,23 +65,30 @@ class Block
 	public static function fromRPCArr(array $rpcArr): static
 	{
 		$block = new static();
-		$block->number           = hexdec($rpcArr["number"]);
-		$block->hash             = Hash::fromHex($rpcArr["hash"]);
-		$block->parentHash       = Hash::fromHex($rpcArr["parentHash"]);
-		$block->nonce            = BlockNonce::fromHex($rpcArr["nonce"]);
-		$block->sha3Uncles       = Hash::fromHex($rpcArr["sha3Uncles"]);
-		$block->logsBloom        = Bloom::fromHex($rpcArr["logsBloom"]);
-		$block->transactionsRoot = Hash::fromHex($rpcArr["transactionsRoot"]);
-		$block->stateRoot        = Hash::fromHex($rpcArr["stateRoot"]);
-		$block->receiptsRoot     = Hash::fromHex($rpcArr["receiptsRoot"]);
-		$block->miner            = Address::fromHex($rpcArr["miner"]);
-		$block->difficulty       = new OOGmp($rpcArr["difficulty"], 16);
-		$block->totalDifficulty  = new OOGmp($rpcArr["totalDifficulty"], 16);
-		$block->extraData        = $rpcArr["extraData"];
-		$block->size             =  hexdec($rpcArr["size"]);
-		$block->gasLimit         =  hexdec($rpcArr["gasLimit"]);
-		$block->gasUsed          =  hexdec($rpcArr["gasUsed"]);
-		$block->timestamp        =  hexdec($rpcArr["timestamp"]);
+		$block->number                   = hexdec($rpcArr["number"]);
+		$block->hash                     = Hash::fromHex($rpcArr["hash"]);
+		$block->parentHash               = Hash::fromHex($rpcArr["parentHash"]);
+		$block->nonce                    = BlockNonce::fromHex($rpcArr["nonce"]);
+		$block->sha3Uncles               = Hash::fromHex($rpcArr["sha3Uncles"]);
+		$block->logsBloom                = Bloom::fromHex($rpcArr["logsBloom"]);
+		$block->transactionsRoot         = Hash::fromHex($rpcArr["transactionsRoot"]);
+		$block->stateRoot                = Hash::fromHex($rpcArr["stateRoot"]);
+		$block->receiptsRoot             = Hash::fromHex($rpcArr["receiptsRoot"]);
+		$block->miner                    = Address::fromHex($rpcArr["miner"]);
+		$block->difficulty               = new OOGmp($rpcArr["difficulty"] ?? 0, 16);
+		$block->totalDifficulty          = new OOGmp($rpcArr["totalDifficulty"] ?? 0, 16);
+		$block->extraData                = $rpcArr["extraData"];
+		$block->parentBeaconBlockRoot    = isset($rpcArr["parentBeaconBlockRoot"])
+											? Hash::fromHex($rpcArr["parentBeaconBlockRoot"]) : null;
+		$block->blobGasUsed              = isset($rpcArr["blobGasUsed"]) ? hexdec($rpcArr["blobGasUsed"]) : null;
+		$block->excessBlobGas            = isset($rpcArr["excessBlobGas"]) ? hexdec($rpcArr["excessBlobGas"]) : null;
+		$block->size                     = hexdec($rpcArr["size"]);
+		$block->gasLimit                 = hexdec($rpcArr["gasLimit"]);
+		$block->gasUsed                  = hexdec($rpcArr["gasUsed"]);
+		$block->timestamp                = hexdec($rpcArr["timestamp"]);
+		$block->validatorWithdrawalsRoot = isset($rpcArr["withdrawalsRoot"])
+											? Hash::fromHex($rpcArr["withdrawalsRoot"]) : null;
+
 		if(empty($rpcArr["transactions"])) {
 			$block->transactions = [];
 		} else {
@@ -111,5 +122,16 @@ class Block
 	public function isEIP1559(): bool
 	{
 		return $this->baseFeePerGas !== null;
+	}
+
+	/**
+	 * Checks if the block looks like coming from EIP-4844 enabled chain by looking if blob fees are defined
+	 * @see https://eips.ethereum.org/EIPS/eip-4844#header-extension
+	 *
+	 * @return bool
+	 */
+	public function isEIP4844(): bool
+	{
+		return $this->blobGasUsed !== null;
 	}
 }

--- a/src/Common/CancunTransaction.php
+++ b/src/Common/CancunTransaction.php
@@ -1,0 +1,170 @@
+<?php
+
+namespace M8B\EtherBinder\Common;
+
+use M8B\EtherBinder\Exceptions\EthBinderArgumentException;
+use M8B\EtherBinder\Exceptions\InvalidHexException;
+use M8B\EtherBinder\Exceptions\InvalidHexLengthException;
+use M8B\EtherBinder\RLP\Encoder;
+use M8B\EtherBinder\Utils\OOGmp;
+
+/**
+ * DencunTransaction is transaction type 3, enabled in Proto-DankSharding ethereum upgrade, defined by EIP 4844
+ *
+ * Note that support is only partial, Ether Binder does not interact with consensus layer at all, so transmitting or
+ *  fetching blobs isn't part of binder.
+ *
+ * @see https://eips.ethereum.org/EIPS/eip-4844
+ */
+class CancunTransaction extends LondonTransaction
+{
+	protected OOGmp $maxFeePerBlobGas;
+	/** @var Hash[]  */
+	protected array $blobVersionedHashes;
+
+	public function __construct()
+	{
+		$this->maxFeePerBlobGas = new OOGmp();
+		parent::__construct();
+	}
+
+	/**
+	 * @throws EthBinderArgumentException
+	 */
+	protected function internalEncodeBin(bool $signing, ?int $signingChainID): string
+	{
+		$nonce            = "0x".dechex($this->nonce);
+		$gasFeePrice      = $this->gasPrice->add($this->gasFeeTip)->toString(true);
+		$gasLimit         = "0x".dechex($this->gas);
+		$to               = $this->to?->toHex();
+		$value            = $this->value->toString(true);
+		$data             = $this->dataHex();
+		$gasFeeTip        = $this->gasFeeTip->toString(true);
+		$chainId          = $this->chainId === null ? null : "0x".dechex($this->chainId);
+		$accessList       = $this->accessList;
+		$blobHashes       = $this->blobVersionedHashes;
+		$maxFeePerBlobGas = $this->maxFeePerBlobGas;
+		$v                = $this->v()->toString(true);
+		$r                = $this->r()->toString(true);
+		$s                = $this->s()->toString(true);
+
+		if($signingChainID !== null) {
+			$this->chainId = $signingChainID;
+			$chainId = $signingChainID;
+		}
+
+		if($chainId === null) {
+			throw new EthBinderArgumentException("chain ID cannot be null for typed transaction");
+		}
+
+		// spec:
+		//   [chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas, gas_limit, to, value, data, access_list,
+		//    max_fee_per_blob_gas, blob_versioned_hashes, y_parity, r, s]
+		// signing spec:
+		//   [chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas, gas_limit, to, value, data, access_list,
+		//     max_fee_per_blob_gas, blob_versioned_hashes]
+		$data = [$chainId, $nonce, $gasFeeTip, $gasFeePrice, $gasLimit, $to, $value, $data, $accessList,
+			$maxFeePerBlobGas, $blobHashes];
+		if(!$signing) {
+			$data[] = $v;
+			$data[] = $r;
+			$data[] = $s;
+		}
+
+		return Encoder::encodeBin([TransactionType::BLOB->toTypeByte(),$data]);
+	}
+
+	/**
+	 *  Returns the transaction type enum.
+	 *
+	 *  @return TransactionType The transaction type enum value.
+	 */
+	public function transactionType(): TransactionType
+	{
+		return TransactionType::BLOB;
+	}
+
+	/**
+	 * @throws InvalidHexException
+	 * @throws InvalidHexLengthException
+	 */
+	protected function blanksFromRPCArr(array $rpcArr): void
+	{
+		parent::blanksFromRPCArr($rpcArr);
+		$this->maxFeePerBlobGas = new OOGmp($rpcArr["maxFeePerBlobGas"]);
+		$this->blobVersionedHashes = [];
+		foreach($rpcArr["blobVersionedHashes"] ?? [] AS $itm) {
+			$this->blobVersionedHashes[] = Hash::fromHex($itm);
+		}
+	}
+
+	protected function setInnerFromRLPValues(array $rlpValues): void
+	{
+		list($chainId, $nonce, $maxPriorityFeePerGas, $maxFeePerGas, $gasLimit, $destination, $amount,
+			$data, $accessList, $maxFeePerBlobGas, $blobHashes, $v, $r, $s) = $rlpValues;
+
+		$this->setDataHex($data);
+		$this->nonce             = hexdec($nonce);
+		$this->gasFeeTip         = new OOGmp($maxPriorityFeePerGas);
+		$this->gasPrice          = (new OOGmp($maxFeePerGas))->sub($this->gasFeeTip);
+		$this->gas               = hexdec(substr($gasLimit, 2));
+		$this->chainId           = hexdec(substr($chainId, 2));
+		$this->to                = Address::fromHex($destination);
+		$this->value             = new OOGmp($amount);
+		$this->accessList        = $accessList;
+		$this->maxFeePerBlobGas  = new OOGmp($maxFeePerBlobGas);
+		$this->v                 = new OOGmp($v);
+		$this->r                 = new OOGmp($r);
+		$this->s                 = new OOGmp($s);
+		$this->signed            = true;
+
+		$this->blobVersionedHashes = [];
+		foreach($blobHashes AS $blobHash) {
+			if($blobHash instanceof Hash) {
+				$this->blobVersionedHashes[] = $blobHash;
+			} else {
+				$this->blobVersionedHashes[] = Hash::fromHex($blobHash);
+			}
+		}
+	}
+
+	/**
+	 * Adds a versioned hash to the blobVersionedHashes array.
+	 *
+	 * @param Hash $hash The versioned hash to add.
+	 */
+	public function addVersionedHash(Hash $hash): void
+	{
+		$this->blobVersionedHashes[] = $hash;
+	}
+
+	/**
+	 * Returns an array of versioned hashes.
+	 *
+	 * @return Hash[] Array of versioned hashes.
+	 */
+	public function versionedHashes(): array
+	{
+		return $this->blobVersionedHashes;
+	}
+
+	/**
+	 * Returns the maximum fee per blob gas.
+	 *
+	 * @return OOGmp The maximum fee per blob gas.
+	 */
+	public function getMaxFeePerBlobGas(): OOGmp
+	{
+		return $this->maxFeePerBlobGas;
+	}
+
+	/**
+	 * Sets the maximum fee per blob gas. Note that this value is not serviced by estimations.
+	 *
+	 * @param OOGmp $maxFeePerBlobGas The maximum fee per blob gas to set.
+	 */
+	public function setMaxFeePerBlobGas(OOGmp $maxFeePerBlobGas): void
+	{
+		$this->maxFeePerBlobGas = $maxFeePerBlobGas;
+	}
+}

--- a/src/Common/TransactionType.php
+++ b/src/Common/TransactionType.php
@@ -54,7 +54,7 @@ enum TransactionType
 			self::LEGACY      => new LegacyTransaction(),
 			self::ACCESS_LIST => new AccessListTransaction(),
 			self::DYNAMIC_FEE => new LondonTransaction(),
-			self::BLOB        => throw new NotSupportedException("transaction blob type is not supported yet"),
+			self::BLOB        => new CancunTransaction(),
 		};
 	}
 


### PR DESCRIPTION
Add support for Dencun transactions type. Fix encoding for changed RPC outputs. Fix London access list setter, update readme for tag.

Block fields are nullable (optional), as this library should be able to talk with both modern networks (such as mainnet) or legacy networks.