### PR TITLE
Fix EIP1559 base fee calculation

### DIFF
--- a/src/Common/LondonTransaction.php
+++ b/src/Common/LondonTransaction.php
@@ -298,6 +298,7 @@ class LondonTransaction extends Transaction
 	public function useRpcEstimatesWithBump(AbstractRPC $rpc, ?Address $from, int $bumpGasPercentage, int $bumpFeePercentage): static
 	{
 		$gas   = ($rpc->ethEstimateGas($this, $from) * ($bumpFeePercentage + 100)) / 100;
+		$gas   = (int)ceil($gas);
 		$base  = Functions::getPessimisticBlockBaseFee($rpc->ethGetBlockByNumber(), 3, EIP1559Config::sepolia()
 		         /* using sepolia as only difference for this config is start block, which is 0. This function is expected
 		            to be called on London transaction for London-enabled chains, regardless of starting block */

--- a/src/Utils/Functions.php
+++ b/src/Utils/Functions.php
@@ -167,7 +167,7 @@ abstract class Functions {
 			return new OOGmp(EIP1559Config::INITIAL_BASE_FEE);
 		}
 
-		$parentGasTarget = $previous->gasLimit / EIP1559Config::ELASTICITY_MULTIPLIER;
+		$parentGasTarget = (int)floor($previous->gasLimit / EIP1559Config::ELASTICITY_MULTIPLIER);
 		if($parentGasTarget == $previous->gasUsed) {
 			return $previous->baseFeePerGas;
 		}


### PR DESCRIPTION
Division could skew the calculation by 1 wei. this fixes it. Also fixes php warning about deprecated implicit conversion